### PR TITLE
Change `Object.LastModified` to a conditionally set pointer

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -155,7 +155,7 @@ func ExampleClient_conditionalRequestsIfModifiedSince() {
 
 	subjects2, err := client.SubjectList(&wanikaniapi.SubjectListParams{
 		Params: wanikaniapi.Params{
-			IfModifiedSince: wanikaniapi.Time(subjects1.LastModified),
+			IfModifiedSince: wanikaniapi.Time(*subjects1.LastModified),
 		},
 	})
 	if err != nil {

--- a/samples/if_modified_since/main.go
+++ b/samples/if_modified_since/main.go
@@ -20,7 +20,7 @@ func main() {
 
 	subjects2, err := client.SubjectList(&wanikaniapi.SubjectListParams{
 		Params: wanikaniapi.Params{
-			IfModifiedSince: wanikaniapi.Time(subjects1.LastModified),
+			IfModifiedSince: wanikaniapi.Time(*subjects1.LastModified),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
It turns out that although `Last-Modified` is set on the vast majority
of WaniKani responses, it's not set on _all_. One example of this case
is if we request a list filtered for specific IDs.

Here we make `Object.LastModified` a pointer to represent the fact that
it may not always have a usable value.