### PR TITLE
Add `subject_types` to "assignment list" parameters

### DIFF
--- a/assignment.go
+++ b/assignment.go
@@ -96,6 +96,7 @@ type AssignmentListParams struct {
 	SRSStages                      []int
 	Started                        *bool
 	SubjectIDs                     []WKID
+	SubjectTypes                   []WKObjectType `json:"subject_types"`
 	Unlocked                       *bool
 	UpdatedAfter                   *WKTime
 }
@@ -156,6 +157,10 @@ func (p *AssignmentListParams) EncodeToQuery() string {
 
 	if p.SubjectIDs != nil {
 		values.Add("subject_ids", joinIDs(p.SubjectIDs, ","))
+	}
+
+	if p.SubjectTypes != nil {
+		values.Add("subject_types", joinObjectTypes(p.SubjectTypes, ","))
 	}
 
 	if p.UpdatedAfter != nil {


### PR DESCRIPTION
Add `subject_types` to the parameters for assignment list. I'm not sure
if this is a field that I missed before, or one that was added to the
API more recently.

Fixes #2.